### PR TITLE
First pass at a transit picker

### DIFF
--- a/web/frontend/src/components/BaseMap.vue
+++ b/web/frontend/src/components/BaseMap.vue
@@ -379,6 +379,10 @@ export default defineComponent({
     map?.on(
       'moveend',
       debounce(() => {
+        if (!map) {
+          console.error('mas was unexpectedly null');
+          return;
+        }
         Prefs.stored().setMostRecentMapCenter(map.getCenter());
         Prefs.stored().setMostRecentMapZoom(map.getZoom());
       }, 2000)

--- a/web/frontend/src/components/RouteListItem.vue
+++ b/web/frontend/src/components/RouteListItem.vue
@@ -1,0 +1,37 @@
+<template>
+  <q-item
+    class="q-my-sm"
+    clickable
+    v-ripple
+    active-class="bg-blue-1"
+    :active="$props.active"
+    v-on:click="$props.clickHandler"
+  >
+    <q-item-section class="col-10" top>
+      <slot />
+    </q-item-section>
+    <q-item-section class="col-2" top style="text-align: right">
+      <q-item-label>
+        {{ durationFormatted }}
+      </q-item-label>
+      <q-item-label>
+        <span class="text-weight-light">{{ distanceFormatted }}</span>
+      </q-item-label>
+    </q-item-section>
+  </q-item>
+  <q-separator spaced />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'RouteListItem',
+  props: {
+    active: Boolean,
+    clickHandler: Function,
+    durationFormatted: String,
+    distanceFormatted: String,
+  },
+});
+</script>

--- a/web/frontend/src/components/RouteListItem.vue
+++ b/web/frontend/src/components/RouteListItem.vue
@@ -1,9 +1,9 @@
 <template>
   <q-item
-    class="q-my-sm"
+    class="route-list-item"
     clickable
     v-ripple
-    active-class="bg-blue-1"
+    active-class="route-list-item--selected"
     :active="$props.active"
     v-on:click="$props.clickHandler"
   >
@@ -19,7 +19,6 @@
       </q-item-label>
     </q-item-section>
   </q-item>
-  <q-separator spaced />
 </template>
 
 <script lang="ts">

--- a/web/frontend/src/components/TransitTimeline.vue
+++ b/web/frontend/src/components/TransitTimeline.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="itinerary-item">
+    <div class="itinerary-item-line"></div>
+    <div
+      v-for="leg in itinerary.legs"
+      :key="leg.startTime"
+      :style="{
+        position: 'relative',
+      }"
+    >
+      <div
+        :style="{
+          position: 'absolute',
+          backgroundColor: leg.transitLeg ? '#d11' : '#aaa',
+          left: `${
+            100 *
+            ((leg.startTime - earliestStart) / (latestArrival - earliestStart))
+          }%`,
+          right: `${Math.round(
+            100 *
+              ((latestArrival - leg.endTime) / (latestArrival - earliestStart))
+          )}%`,
+          height: '3em',
+          top: '-2em',
+          marginLeft: '0.2em',
+          marginRight: '0.2em',
+          borderRadius: '0.5em',
+        }"
+      >
+        <q-icon
+          v-if="
+            leg.mode === 'BUS' &&
+            (leg.endTime - leg.startTime) / (latestArrival - earliestStart) >
+              0.1
+          "
+          name="directions_bus"
+          color="black"
+          size="sm"
+          :style="{
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }"
+        ></q-icon>
+        <q-icon
+          v-if="
+            leg.mode === 'WALK' &&
+            (leg.endTime - leg.startTime) / (latestArrival - earliestStart) >
+              0.1
+          "
+          name="directions_walk"
+          color="black"
+          size="sm"
+          :style="{
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }"
+        ></q-icon>
+        <q-icon
+          v-if="
+            (leg.mode === 'TRAIN' || leg.mode === 'TRAM') &&
+            (leg.endTime - leg.startTime) / (latestArrival - earliestStart) >
+              0.1
+          "
+          name="directions_train"
+          color="black"
+          size="sm"
+          :style="{
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+          }"
+        ></q-icon>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'TransitTimeline',
+  props: ['itinerary', 'earliestStart', 'latestArrival'],
+});
+</script>

--- a/web/frontend/src/css/app.scss
+++ b/web/frontend/src/css/app.scss
@@ -82,7 +82,6 @@
 .itinerary-item {
   flex-grow: 1;
   position: static;
-  background-color: $dark;
   min-width: calc(max(40%, 300px));
   height: 0;
   padding: 2.5em;
@@ -96,7 +95,7 @@
 
 .itinerary-item-line {
   position: relative;
-  background-color: #fff;
+  background-color: #ddd;
   top: -0.25em;
   height: 0.5em;
   border-radius: 0.25em;

--- a/web/frontend/src/css/app.scss
+++ b/web/frontend/src/css/app.scss
@@ -203,3 +203,13 @@ html {
 body {
   height: 100%;
 }
+
+.route-list-item {
+  border-bottom: solid $separator 1px;
+  padding: 16px;
+}
+
+.route-list-item--selected {
+  border-left: solid $accent 8px;
+  padding-left: 8px;
+}

--- a/web/frontend/src/css/quasar.variables.scss
+++ b/web/frontend/src/css/quasar.variables.scss
@@ -17,8 +17,12 @@ $secondary: #26a69a;
 $accent: #9c27b0;
 
 $dark: #1d1d1d;
+$dark-page: #121212;
 
 $positive: #21ba45;
 $negative: #c10015;
 $info: #31ccec;
 $warning: #f2c037;
+
+// components
+$separator: #ccc;

--- a/web/frontend/src/i18n/en-US/index.ts
+++ b/web/frontend/src/i18n/en-US/index.ts
@@ -4,6 +4,7 @@ export default {
   could_not_get_gps_location: 'Could not get GPS location',
   dropped_pin: 'Dropped Pin',
   via_$place: 'Via {place}',
+  via$transit_route: 'Via route {transitRoute}',
   times: {
     $n_seconds: '{n} seconds',
     $n_minute: '{n} minute',
@@ -13,6 +14,7 @@ export default {
     $n_hour: '{n} hour',
     $n_hours: '{n} hours',
   },
+  time_range$startTime$endTime: '{startTime} - {endTime}',
   go_home: 'Go Home',
   oops_nothing_here: 'Oops. Nothing here...',
   search: {
@@ -30,4 +32,5 @@ export default {
     kilometers: 'km',
     miles: 'mi',
   },
+  walk_distance: '{preformattedDistance} walk',
 };

--- a/web/frontend/src/layouts/MainLayout.vue
+++ b/web/frontend/src/layouts/MainLayout.vue
@@ -1,8 +1,8 @@
 <template>
   <q-layout view="lHh Lpr lFf">
     <div class="mainContainer">
-      <router-view></router-view>
-      <base-map ref="basemap"></base-map>
+      <router-view />
+      <base-map ref="basemap" />
     </div>
   </q-layout>
 </template>

--- a/web/frontend/src/models/Itinerary.ts
+++ b/web/frontend/src/models/Itinerary.ts
@@ -1,0 +1,124 @@
+import { LngLat } from 'maplibre-gl';
+import { i18n } from 'src/i18n/lang';
+import {
+  OTPClient,
+  OTPItinerary,
+  OTPItineraryLeg,
+  OTPMode,
+  OTPLegGeometry,
+} from 'src/services/OTPClient';
+import { DistanceUnits } from 'src/utils/models';
+import {
+  formatDistance,
+  formatDuration,
+  kilometersToMiles,
+} from 'src/utils/routes';
+
+export default class Itinerary {
+  private raw: OTPItinerary;
+  legs: ItineraryLeg[];
+  private distanceUnits: DistanceUnits;
+
+  constructor(otp: OTPItinerary, distanceUnits: DistanceUnits) {
+    this.raw = otp;
+    this.legs = otp.legs.map((otpLeg) => new ItineraryLeg(otpLeg));
+    this.distanceUnits = distanceUnits;
+  }
+
+  public static async fetchBest(
+    from: LngLat,
+    to: LngLat,
+    distanceUnits: DistanceUnits
+  ): Promise<Itinerary[]> {
+    const otpItineraries = await OTPClient.fetchItineraries(from, to, 5);
+    return otpItineraries.map((otp) => Itinerary.fromOtp(otp, distanceUnits));
+  }
+
+  static fromOtp(raw: OTPItinerary, distanceUnits: DistanceUnits): Itinerary {
+    return new Itinerary(raw, distanceUnits);
+  }
+
+  public get duration(): number {
+    return this.raw.duration;
+  }
+
+  public durationFormatted(): string {
+    return formatDuration(this.raw.duration);
+  }
+
+  public get startTime(): number {
+    return this.raw.startTime;
+  }
+
+  public startStopTimesFormatted(): string {
+    return i18n.global.t('time_range$startTime$endTime', {
+      startTime: formatTime(this.startTime),
+      endTime: formatTime(this.endTime),
+    });
+  }
+
+  public get endTime(): number {
+    return this.raw.endTime;
+  }
+
+  get walkingDistanceMeters(): number {
+    return this.raw.walkDistance;
+  }
+
+  public walkingDistanceFormatted(): string {
+    let distance = this.walkingDistanceMeters;
+    if (this.distanceUnits != DistanceUnits.Kilometers) {
+      distance = kilometersToMiles(distance / 1000);
+    }
+
+    return formatDistance(distance, this.distanceUnits);
+  }
+
+  public get viaRouteFormatted(): string | undefined {
+    return this.legs.map((leg) => leg.shortName).join(', ');
+  }
+}
+
+function formatTime(millis: number): string {
+  return new Date(millis).toLocaleTimeString([], { timeStyle: 'short' });
+}
+
+class ItineraryLeg {
+  readonly raw: OTPItineraryLeg;
+  constructor(otp: OTPItineraryLeg) {
+    this.raw = otp;
+  }
+
+  get shortName(): string {
+    switch (this.mode) {
+      case OTPMode.Walk:
+        return '🚶‍♀️';
+      case OTPMode.Bus:
+        return '🚍' + this.raw.routeShortName;
+      case OTPMode.Tram:
+        return '🚊' + this.raw.routeShortName;
+      case OTPMode.Train:
+        return '🚆' + this.raw.routeShortName;
+    }
+  }
+
+  get mode(): OTPMode {
+    return this.raw.mode;
+  }
+
+  get legGeometry(): OTPLegGeometry {
+    return this.raw.legGeometry;
+  }
+
+  get transitLeg(): boolean {
+    return this.raw.transitLeg;
+  }
+
+  get startTime(): number {
+    return this.raw.startTime;
+  }
+
+  get endTime(): number {
+    return this.raw.endTime;
+  }
+}

--- a/web/frontend/src/models/Place.ts
+++ b/web/frontend/src/models/Place.ts
@@ -1,5 +1,5 @@
 import { DistanceUnits } from '../utils/models';
-import { PeliasClient } from '../services/PeliasClient';
+import PeliasClient from 'src/services/PeliasClient';
 import { LngLat } from 'maplibre-gl';
 
 /// PlaceId can be either a LngLat or a gid (but not both).

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -35,11 +35,11 @@
   <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
     <q-list>
       <route-list-item
+        v-for="item in $data.routes"
         :click-handler="() => clickRoute(item)"
         :active="$data.activeRoute === item"
         :duration-formatted="item[1].durationFormatted"
         :distance-formatted="item[1].lengthFormatted"
-        v-for="item in $data.routes"
         v-bind:key="JSON.stringify(item)"
       >
         <q-item-label>

--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -34,37 +34,29 @@
   </div>
   <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
     <q-list>
-      <div v-for="item in $data.routes" v-bind:key="JSON.stringify(item)">
-        <q-item
-          class="q-my-sm"
-          clickable
-          v-ripple
-          :active="$data.activeRoute === item"
-          v-on:click="clickRoute(item)"
-          active-class="bg-blue-1"
-        >
-          <q-item-section>
-            <q-item-label>
-              {{ item[1].timeFormatted }}
-              <span class="text-weight-light">{{
-                ' (' + item[1].lengthFormatted + ')'
-              }}</span>
-            </q-item-label>
-            <q-item-label caption v-if="item[1].viaRoadsFormatted.length !== 0">
-              {{ $t('via_$place', { place: item[1].viaRoadsFormatted }) }}
-            </q-item-label>
-          </q-item-section>
-
-          <q-item-section side>
-            <q-icon
-              name="directions"
-              v-on:click="showSteps(item)"
-              :color="item === $data.activeRoute ? 'blue' : ''"
-            />
-          </q-item-section>
-        </q-item>
-        <q-separator spaced />
-      </div>
+      <route-list-item
+        :click-handler="() => clickRoute(item)"
+        :active="$data.activeRoute === item"
+        :duration-formatted="item[1].durationFormatted"
+        :distance-formatted="item[1].lengthFormatted"
+        v-for="item in $data.routes"
+        v-bind:key="JSON.stringify(item)"
+      >
+        <q-item-label>
+          {{ $t('via_$place', { place: item[1].viaRoadsFormatted }) }}
+        </q-item-label>
+        <q-item-label>
+          <q-btn
+            style="margin-left: -6px"
+            padding="6px"
+            flat
+            icon="directions"
+            label="Details"
+            size="sm"
+            v-on:click="showSteps(item)"
+          />
+        </q-item-label>
+      </route-list-item>
     </q-list>
   </div>
 </template>
@@ -84,6 +76,7 @@ import { useQuasar } from 'quasar';
 import { CacheableMode, getRoutes } from 'src/utils/routecache';
 import { Route, ProcessedRouteSummary, summarizeRoute } from 'src/utils/routes';
 import { Place } from 'src/models/Place';
+import RouteListItem from 'src/components/RouteListItem.vue';
 
 var toPoi: Ref<POI | undefined> = ref(undefined);
 var fromPoi: Ref<POI | undefined> = ref(undefined);
@@ -104,7 +97,7 @@ export default defineComponent({
       activeRoute: undefined,
     };
   },
-  components: { SearchBox },
+  components: { SearchBox, RouteListItem },
   methods: {
     poiDisplayName,
     summarizeRoute,

--- a/web/frontend/src/pages/MultimodalPage.vue
+++ b/web/frontend/src/pages/MultimodalPage.vue
@@ -35,8 +35,9 @@
   <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
     <q-list>
       <route-list-item
-        :click-handler="() => changeItinerary(index)"
         v-for="(item, index) in itineraries"
+        :click-handler="() => changeItinerary(index)"
+        :active="$data.itineraryIndex === index"
         :duration-formatted="item.durationFormatted()"
         distance-formatted=""
         v-bind:key="JSON.stringify(item)"

--- a/web/frontend/src/services/OTPClient.ts
+++ b/web/frontend/src/services/OTPClient.ts
@@ -1,0 +1,47 @@
+import { LngLat } from 'maplibre-gl';
+
+export type OTPLegGeometry = {
+  points: string;
+};
+
+export enum OTPMode {
+  Walk = 'WALK',
+  Bus = 'BUS',
+  Train = 'TRAIN',
+  Tram = 'TRAM',
+}
+
+export type OTPItineraryLeg = {
+  startTime: number;
+  endTime: number;
+  mode: OTPMode;
+  transitLeg: boolean;
+  legGeometry: OTPLegGeometry;
+  routeShortName?: string;
+};
+
+export type OTPItinerary = {
+  generalizedCost: number;
+  duration: number;
+  startTime: number;
+  endTime: number;
+  walkDistance: number;
+  legs: OTPItineraryLeg[];
+};
+
+export class OTPClient {
+  public static async fetchItineraries(
+    from: LngLat,
+    to: LngLat,
+    count: number
+  ): Promise<OTPItinerary[]> {
+    const rawResponse = await fetch(
+      `/otp/routers/default/plan?fromPlace=${from.lat},${from.lng}&toPlace=${to.lat},${to.lng}&numItineraries=${count}`
+    );
+    const response = await rawResponse.json();
+    return response.plan.itineraries.sort(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (a: any, b: any) => a.endTime - b.endTime
+    );
+  }
+}

--- a/web/frontend/src/services/PeliasClient.ts
+++ b/web/frontend/src/services/PeliasClient.ts
@@ -2,7 +2,7 @@ import { LngLat } from 'maplibre-gl';
 
 type PlaceResponse = GeoJSON.FeatureCollection;
 
-export class PeliasClient {
+export default class PeliasClient {
   static async findByGid(gid: string): Promise<PlaceResponse> {
     const response = await fetch(`/pelias/v1/place?ids=${gid}`);
     if (response.ok) {

--- a/web/frontend/src/third_party/decodePath.ts
+++ b/web/frontend/src/third_party/decodePath.ts
@@ -1,10 +1,10 @@
 // This function is copied from GraphHopper's web client, licensed under the terms of the Apache License, version 2.0
 // Copyright 2012-2013 Peter Karich
-export function decodeOtpPath(encoded: string) {
+export function decodeOtpPath(encoded: string): [number, number][] {
   // var start = new Date().getTime();
   const len = encoded.length;
   let index = 0;
-  const array = [];
+  const array: [number, number][] = [];
   let lat = 0;
   let lng = 0;
 

--- a/web/frontend/src/utils/geomath.ts
+++ b/web/frontend/src/utils/geomath.ts
@@ -1,6 +1,15 @@
+import { LngLat } from 'maplibre-gl';
+
 export interface LongLat {
   long: number;
   lat: number;
+}
+
+/// Unfortunately we use (at least) two different objects for storing latitude and longitude.
+/// So this is a helper to convert between two of them.
+/// Long term I'd like to consolidate around fewer.
+export function toLngLat(longLat: LongLat): LngLat {
+  return new LngLat(longLat.long, longLat.lat);
 }
 
 export function fastDistanceMeters(p1: LongLat, p2: LongLat): number {

--- a/web/frontend/src/utils/routes.ts
+++ b/web/frontend/src/utils/routes.ts
@@ -1,4 +1,5 @@
 import { i18n } from 'src/i18n/lang';
+import { DistanceUnits } from './models';
 
 export interface RouteLegManeuver {
   begin_shape_index: number;
@@ -33,9 +34,9 @@ export interface Route {
 }
 
 export interface ProcessedRouteSummary {
-  timeSeconds: number;
+  durationSeconds: number;
   viaRoads: string[];
-  timeFormatted: string;
+  durationFormatted: string;
   viaRoadsFormatted: string;
   lengthFormatted: string;
 }
@@ -69,9 +70,9 @@ export function summarizeRoute(route: Route): ProcessedRouteSummary {
     viaRoads.push(road);
   }
   return {
-    timeSeconds: route.summary.time,
+    durationSeconds: route.summary.time,
     viaRoads: viaRoads,
-    timeFormatted: formatTime(route.summary.time),
+    durationFormatted: formatDuration(route.summary.time),
     viaRoadsFormatted: viaRoads.join(
       i18n.global.t('punctuation_list_seperator')
     ),
@@ -121,12 +122,12 @@ function costliestRoads(
   return roadCosts;
 }
 
-function formatTime(timeSeconds: number): string {
-  const totalMinutes = Math.round(timeSeconds / 60);
+export function formatDuration(durationSeconds: number): string {
+  const totalMinutes = Math.round(durationSeconds / 60);
   let timeString = '';
   if (totalMinutes < 1) {
     timeString = i18n.global.t('times.$n_seconds', {
-      n: Math.round(timeSeconds),
+      n: Math.round(durationSeconds),
     });
   } else if (totalMinutes < 60) {
     timeString = i18n.global.t('times.$n_minutes', { n: totalMinutes });
@@ -159,6 +160,23 @@ function formatTime(timeSeconds: number): string {
     );
   }
   return timeString;
+}
+
+export function kilometersToMiles(kilometers: number): number {
+  return kilometers * 0.62137119;
+}
+
+export function formatDistance(
+  distance: number,
+  units: DistanceUnits,
+  precision = 1
+): string {
+  const rounded = distance.toFixed(precision);
+  if (units == DistanceUnits.Kilometers) {
+    return `${rounded} ${i18n.global.t('shortened_distances.kilometers')}`;
+  } else {
+    return `${rounded} ${i18n.global.t('shortened_distances.miles')}`;
+  }
 }
 
 export function valhallaTypeToIcon(type: number) {


### PR DESCRIPTION
I took a stab at making the transit UI usable, and in the process tried to unify the route picking options between the MultiModalPage (transit) and the AlternatesPage (non-transit) page.

Ultimately I feel like those two should be a single page, so I've been working on extracting commonalities, but we're not there yet.

I tried to keep the choice cells UI short by default so the user can fit a few options on their screen without covering the map.  The existing transit timeline/waterfall view was neat, but currently it takes up more space than its worth imo. It's still there, but hidden behind a button.

I'd like to make some further improvements to it eventually, but for now it's hidden behind the "details" button and much smaller version is shown inline in the card.

Also, there's obviously still a lot of improvements to make here, but this seemed like a reasonable check-in point where things are strictly improving.

**non-transit before:**
<img width="434" alt="Screenshot 2022-11-11 at 4 49 00 PM" src="https://user-images.githubusercontent.com/217057/201448477-9894d27c-256d-41f2-8acf-c8b685bf7be6.png">

**non-transit after:**
<img width="434" alt="Screenshot 2022-11-11 at 4 31 50 PM" src="https://user-images.githubusercontent.com/217057/201448135-4dc7c5c7-9cd3-4ea4-a88d-30c275ade704.png">

**transit before:**
<img width="434" alt="Screenshot 2022-11-11 at 4 49 43 PM" src="https://user-images.githubusercontent.com/217057/201448471-51978ab9-50db-4ec2-b9df-94f7198a4d76.png">

**transit after:**
<img width="434" alt="Screenshot 2022-11-11 at 4 32 32 PM" src="https://user-images.githubusercontent.com/217057/201448126-274c59f4-6102-4a0e-82e6-00bc7ebb25ff.png">

