### PR TITLE
tweak transit picker layout

### DIFF
--- a/web/frontend/src/models/Itinerary.ts
+++ b/web/frontend/src/models/Itinerary.ts
@@ -75,7 +75,7 @@ export default class Itinerary {
   }
 
   public get viaRouteFormatted(): string | undefined {
-    return this.legs.map((leg) => leg.shortName).join(', ');
+    return this.legs.map((leg) => leg.shortName).join('→');
   }
 }
 

--- a/web/frontend/src/pages/MultimodalPage.vue
+++ b/web/frontend/src/pages/MultimodalPage.vue
@@ -49,7 +49,11 @@
           {{ item.viaRouteFormatted }}
         </q-item-label>
         <q-item-label caption>
-          {{ walkText(item) }}
+          {{
+            $t('walk_distance', {
+              preformattedDistance: item.walkingDistanceFormatted(),
+            })
+          }}
         </q-item-label>
         <q-item-label
           :hidden="$data.itineraryIndex === index && areStepsVisible(index)"
@@ -170,11 +174,6 @@ export default defineComponent({
     searchBoxDidSelectToPoi(poi?: POI) {
       this.toPoi = poi;
       this.rewriteUrl();
-    },
-    walkText(item: Itinerary): string {
-      return i18n.global.t('walk_distance', {
-        preformattedDistance: item.walkingDistanceFormatted(),
-      });
     },
     rewriteUrl: async function () {
       if (!fromPoi.value?.position && !toPoi.value?.position) {

--- a/web/frontend/src/pages/MultimodalPage.vue
+++ b/web/frontend/src/pages/MultimodalPage.vue
@@ -48,7 +48,7 @@
         <q-item-label caption>
           {{ item.viaRouteFormatted }}
         </q-item-label>
-        <q-item-label caption>
+        <q-item-label caption :hidden="$data.itineraryIndex !== index">
           {{
             $t('walk_distance', {
               preformattedDistance: item.walkingDistanceFormatted(),


### PR DESCRIPTION
- [www] better separator for timeline
- [www] inline method, no change in behavior
- [www] narrow inactive routes by hiding walking distance

**before**
<img width="427" alt="Screenshot 2022-11-16 at 1 21 32 PM" src="https://user-images.githubusercontent.com/217057/202297193-cf1a2180-3ce5-4cd1-b068-91a049a60ce9.png">

**after**
<img width="439" alt="Screenshot 2022-11-16 at 1 21 56 PM" src="https://user-images.githubusercontent.com/217057/202297186-a690df73-f776-4002-8f77-c64bf1b33bf2.png">
