### PR TITLE
fixup "via" text

### DIFF
--- a/web/frontend/src/i18n/en-US/index.ts
+++ b/web/frontend/src/i18n/en-US/index.ts
@@ -3,8 +3,8 @@ export default {
   my_location: 'My Location',
   could_not_get_gps_location: 'Could not get GPS location',
   dropped_pin: 'Dropped Pin',
-  via_$place: 'Via {place}',
-  via$transit_route: 'Via route {transitRoute}',
+  via_$place: 'via {place}',
+  via$transit_route: 'via route {transitRoute}',
   times: {
     $n_seconds: '{n} seconds',
     $n_minute: '{n} minute',


### PR DESCRIPTION
Simplify, use length not cost, and prefer non-empty 

Short trips would often just not have a route name since they didn't pass the threshold of minimal cost.

Previously it was based on "cost" not length, which would mean that, e.g. driving down a long stretch of road with a left turn just before the arrival, would be named after the left turn rather than the 99% of your trip. I think length is a more intuitive naming mechanism for routes than cost.
