### PR TITLE
[www] remove ripple animations

### DIFF
--- a/web/frontend/src/components/RouteListItem.vue
+++ b/web/frontend/src/components/RouteListItem.vue
@@ -2,7 +2,6 @@
   <q-item
     class="route-list-item"
     clickable
-    v-ripple
     active-class="route-list-item--selected"
     :active="$props.active"
     v-on:click="$props.clickHandler"

--- a/web/frontend/src/components/TravelModeBar.vue
+++ b/web/frontend/src/components/TravelModeBar.vue
@@ -5,6 +5,7 @@
       v-if="transitRoutingEnabled"
       unelevated
       rounded
+      :ripple="false"
       size="sm"
       :to="`/multimodal/${poiToUrlArg(toPoi)}/${poiToUrlArg(fromPoi)}`"
       :color="currentMode === 'transit' ? 'primary' : undefined"
@@ -15,6 +16,7 @@
       icon="directions_car"
       unelevated
       rounded
+      :ripple="false"
       size="sm"
       :to="`/directions/car/${poiToUrlArg(toPoi)}/${poiToUrlArg(fromPoi)}`"
       :color="currentMode === 'car' ? 'primary' : undefined"
@@ -25,6 +27,7 @@
       icon="directions_bike"
       unelevated
       rounded
+      :ripple="false"
       size="sm"
       :to="`/directions/bicycle/${poiToUrlArg(toPoi)}/${poiToUrlArg(fromPoi)}`"
       :color="currentMode === 'bicycle' ? 'primary' : undefined"
@@ -35,6 +38,7 @@
       icon="directions_walk"
       unelevated
       rounded
+      :ripple="false"
       size="sm"
       :to="`/directions/walk/${poiToUrlArg(toPoi)}/${poiToUrlArg(fromPoi)}`"
       :color="currentMode === 'walk' ? 'primary' : undefined"

--- a/web/frontend/src/pages/StepsPage.vue
+++ b/web/frontend/src/pages/StepsPage.vue
@@ -9,7 +9,7 @@
   <div class="bottom-card bg-white" ref="bottomCard" v-if="fromPoi && toPoi">
     <q-list>
       <div v-for="item in $data.steps" v-bind:key="JSON.stringify(item)">
-        <q-item class="q-my-sm" v-ripple active-class="bg-blue-1">
+        <q-item class="q-my-sm" active-class="bg-blue-1">
           <q-item-section avatar>
             <q-icon :name="valhallaTypeToIcon(item.type)" />
           </q-item-section>


### PR DESCRIPTION
It looks really bad on low-end devices (like my phone).

It's misleading in the steps page, because there is no interaction (yet).

It's inconsistent on the mode-picker buttons because it shows when
switching modes within Alternates, but there is no ripple when switching
to the multimodal page (and vice versa).

And, I guess also I'm just asserting my spartan design preferences.
