### PR TITLE
[www] fix resize after changing routes

### DIFF
--- a/web/frontend/src/pages/AlternatesPage.vue
+++ b/web/frontend/src/pages/AlternatesPage.vue
@@ -235,8 +235,9 @@ export default defineComponent({
           'line-width': 6,
         }
       );
-
-      this.resizeMap();
+      setTimeout(async () => {
+        this.resizeMap();
+      });
       const summary = selectedRoute.summary;
       getBaseMap()?.fitBounds(
         new LngLatBounds(


### PR DESCRIPTION
This is a hack... we just want to make sure the routes have been redrawn before sizing the bottom card. I'm sure there's a less janky way, but this is a quick fix.